### PR TITLE
llppac: Create font cache directory if necessary

### DIFF
--- a/misc/llppac
+++ b/misc/llppac
@@ -17,6 +17,7 @@ executable_p() {
 }
 
 maketext() {
+    [ -d "$cachedir/fonts" ] || mkdir "$cachedir/fonts"
     cat >"$cachedir/fonts/text" <<EOF
 Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do
 eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad


### PR DESCRIPTION
Hey,

I don't know if this is the right place to get in contact with this project.
Anyways here is a small fix for a bug I encountered, cause the fonts directory wasn't created in the cache directory when viewing font files with llppac.

Thanks for the great project!