### PR TITLE
Minor fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/.config
+/build/

--- a/configure.sh
+++ b/configure.sh
@@ -2,7 +2,7 @@
 set -e
 
 unset cflags
-test $(uname -m) = "x86)_64" && buildtype=native || buildtype=release
+test $(uname -m) = "x86_64" && buildtype=native || buildtype=release
 
 usage () {
     echo "$1"

--- a/main.ml
+++ b/main.ml
@@ -1549,7 +1549,7 @@ let onpagerect pageno f =
   in
   if pageno >= 0 && pageno < Array.length b
   then
-    let (_, _, _, (w, h, _, _)) = b.(pageno) in
+    let (_, _, _, (_, w, h, _)) = b.(pageno) in
     f w h
 ;;
 


### PR DESCRIPTION
Now the remote command 'rect' works, but in a difficult to use way, in my oppinion.
It uses the x and y coordinates of the window, correct me if that is not the case.
I would suggest it uses some kind of measurement from the pdf (pixel?) or relative x and y coordinates.
I tried to implement it, but I couldn't figure out how to get the size of the pdf, and not the window.