### PR TITLE
Use git submodule to manage mupdf dependancy

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "mupdf"]
+	path = mupdf
+	url = git://git.ghostscript.com/mupdf.git

--- a/BUILDING
+++ b/BUILDING
@@ -4,7 +4,7 @@ to be built and installed to use llpp.
 MuPDF is included as a git submodule, which needs to be initialized
 before building llpp. This is done with the following two commands
   git submodule init
-  git submodule update
+  git submodule update --recursive
 
 After that, change into the MuPDF directory and build it:
   cd mupdf

--- a/BUILDING
+++ b/BUILDING
@@ -1,10 +1,14 @@
 MuPDF[1] rendering library is used to do the actual work, so it needs
 to be built and installed to use llpp.
 
-Note that MuPDF is a moving target therefore below is the commit id
-of the git version of MuPDF that this version of llpp is known to work
-with:
-7dc088630b8b8871decad9d58985a9205790185e
+MuPDF is included as a git submodule, which needs to be initialized
+before building llpp. This is done with the following two commands
+  git submodule init
+  git submodule update
+
+After that, change into the MuPDF directory and build it:
+  cd mupdf
+  make
 
 llpp also depends on OCaml[2] (version 4.02.x), LablGL[3] having a C
 compiler wouldn't hurt either.

--- a/build.ninja
+++ b/build.ninja
@@ -1,9 +1,9 @@
 cc = gcc
 include .config
 ocamlflags = -warn-error +a -w +a -g -safe-string
-libs = -lmupdf $mujs -lpthread -L$mupdf/build/$buildtype
+libs = -lmupdf $mujs -lpthread -Lmupdf/build/$buildtype
 
-cflags = $cflags -Wall -Werror -I$mupdf/include -g $
+cflags = $cflags -Wall -Werror -Imupdf/include -g $
        -std=c99 -pedantic-errors -Wunused-parameter -Wsign-compare -Wshadow
 
 rule cc

--- a/configure.sh
+++ b/configure.sh
@@ -7,7 +7,7 @@ test $(uname -m) = "x86_64" && buildtype=native || buildtype=release
 usage () {
     echo "$1"
     cat 1>&2 <<EOF
-usage: $0 [-F] [-b build-type] [-O] [-n] [mudir]
+usage: $0 [-F] [-b build-type] [-O] [-n]
 options:
  -F: use fontconfig
  -b: MuPDF's build type [default native]
@@ -15,7 +15,6 @@ options:
  -n: use native OCaml compiler (bytecode otherwise)
 
  build-type = debug|release|native
- mudir      = path to MuPDF's git checkout
 EOF
     exit $2
 }
@@ -29,10 +28,6 @@ while getopts nFb:O opt; do
         ?) usage "" 0;;
     esac
 done
-shift $((OPTIND - 1))
-
-mupdf="$1"
-test -e "$mupdf" || usage "Don't know where to find MuPDF's git checkout" 1
 
 pkgs="freetype2 zlib openssl" # j(peg|big2dec)?
 test $fontconfig && pkgs="$pkgs fontconfig" || true
@@ -73,11 +68,10 @@ cflags=$cflags -O $(pkg-config --cflags $pkgs)
 lflags=$libs
 srcdir=$(cd >/dev/null $(dirname $0) && pwd -P)
 buildtype=$buildtype
-mupdf=$mupdf
 builddir=$builddir
 lablglcflags=$lablglcflags
 EOF
- test -e $mupdf/build/$buildtype/libmujs.a && echo 'mujs=-lmujs'
+ test -e mupdf/build/$buildtype/libmujs.a && echo 'mujs=-lmujs'
  test $native && {
      echo "cmo=.cmx"
      echo "cma=.cmxa"


### PR DESCRIPTION
This uses git submodules to embed mupdf into the existing source code.
I find it to be easier than having the commit id in the BUILDING file and pointing configure.sh to mupdf's checkout directory.
See http://www.git-scm.com/book/en/v2/Git-Tools-Submodules for a good read on submodules.
I also pulled the latest changes in mupdf, because llpp wouldn't build with the version given in BUILDING.