### PR TITLE
Fix Date of Quick Bookmarks

### DIFF
--- a/main.ml
+++ b/main.ml
@@ -4690,10 +4690,10 @@ let quickbookmark ?title () =
         match title with
         | None ->
             let tm = Unix.localtime (now ()) in
-            Printf.sprintf "Quick (page %d) (bookmarked at %d/%d/%d %d:%d)"
+            Printf.sprintf "Quick (page %d) (bookmarked at %02d/%02d/%d %02d:%02d)"
               (l.pageno+1)
               tm.Unix.tm_mday
-              tm.Unix.tm_mon
+              (tm.Unix.tm_mon+1)
               (tm.Unix.tm_year + 1900)
               tm.Unix.tm_hour
               tm.Unix.tm_min


### PR DESCRIPTION
Always display date and time with two numbers (e.g. 06:01 instead of 6:1)
Fix the month, which was off by one.