### PR TITLE
OS X: recognize X11 unix socket path in $DISPLAY

### DIFF
--- a/wsi.ml
+++ b/wsi.ml
@@ -1156,7 +1156,7 @@ let init t rootwid w h platform =
   let aname, adata = getauth host dispnum in
   let fd =
     let fd, addr =
-      if emptystr host || host = "unix"
+      if emptystr host || host.[0] = '/' || host = "unix"
       then
         let addr =
           match platform with


### PR DESCRIPTION
Typically on OS X the `$DISPLAY` variable looks like this:
```
$ echo $DISPLAY
/private/tmp/com.apple.launchd.4OZW82jiLM/org.macosforge.xquartz:0
```
The current code tries to look up the file path as a hostname, which obviously fails.