### PR TITLE
Add minimal man pages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@
 /.tramp_history
 test/
 mupdf
+/man/*.xml
+/man/*.1

--- a/man/Makefile
+++ b/man/Makefile
@@ -1,0 +1,12 @@
+.PHONY: all
+all: llpp.1 llppac.1 llpphtml.1
+
+%.1: %.xml
+	xmlto man -o . $<
+
+%.xml: %.man asciidoc.conf
+	asciidoc -d manpage -b docbook -f asciidoc.conf -o $@ $<
+
+.PHONY: clean
+clean:
+	rm -f llpp.1 llppac.1 llpphtml.1

--- a/man/asciidoc.conf
+++ b/man/asciidoc.conf
@@ -1,0 +1,17 @@
+ifdef::doctype-manpage[]
+ifdef::backend-docbook[]
+[header]
+template::[header-declarations]
+<refentry>
+<refmeta>
+<refentrytitle>{mantitle}</refentrytitle>
+<manvolnum>{manvolnum}</manvolnum>
+<refmiscinfo class="source">llpp</refmiscinfo>
+<refmiscinfo class="manual">llpp Manual</refmiscinfo>
+</refmeta>
+<refnamediv>
+  <refname>{manname}</refname>
+  <refpurpose>{manpurpose}</refpurpose>
+</refnamediv>
+endif::backend-docbook[]
+endif::doctype-manpage[]

--- a/man/llpp.man
+++ b/man/llpp.man
@@ -12,7 +12,8 @@ llpp [-c path] [-css path] [-cxack] [-dest named-dest] [-embed window-id] [-f pa
 == DESCRIPTION
 
 *llpp* is a graphical PDF viewer that can be totally controlled without a mouse.
-It is based on the MuPDF library and uses default keybindings that resemble less(1).
+Normally MuPDF (https://mupdf.com/) is used to render the document.
+The default keybindings resemble those of less(1), but can be configured by the user.
 
 == OPTIONS
 

--- a/man/llpp.man
+++ b/man/llpp.man
@@ -1,0 +1,134 @@
+llpp(1)
+=======
+
+== NAME
+
+llpp - a graphical PDF viewer which aims to superficially resemble less
+
+== SYNOPSIS
+
+llpp [-c path] [-css path] [-cxack] [-dest named-dest] [-embed window-id] [-f path] [-gc] [-help|--help] [-last] [-no-title] [-origin origin] [-p password] [-page page-number] [-remote path] [-tcf path] [-v] [-wtmode] some.pdf
+
+== DESCRIPTION
+
+*llpp* is a graphical PDF viewer that can be totally controlled without a mouse.
+It is based on the MuPDF library and uses default keybindings that resemble less(1).
+
+== OPTIONS
+
+-c path::
+Set path to the configuration file.
+
+-css path::
+Set path to the style sheet to use with EPUB/HTML.
+
+-cxack::
+Cut corners.
+
+-dest named-dest::
+Set named destination.
+
+-embed window-id::
+Embed into window.
+
+-f path::
+Set path to the user interface font.
+
+-gc::
+Collect config garbage.
+
+-help, --help::
+Display this list of options.
+
+-last::
+Open last document.
+
+-no-title::
+ignore document title.
+
+-origin origin::
+<undocumented>.
+
+-p password::
+Set password.
+
+-page page-number::
+Jump to page.
+
+-remote path::
+Set path to the source of remote commands.
+
+-tcf path::
+Set path to the trim cache file.
+
+-v::
+Print version and exit.
+
+-wtmode::
+Operate in wt mode.
+
+== FILES
+
+=== ~/.config/llpp.conf
+
+This is the user specific configuration file. If $XDG_CONFIG_HOME is set
+$XDG_CONFIG_HOME/llpp.conf is used instead. It has a XML structure
+
+You can specify a custom path using the -c option.
+
+.Configuration structure
+-------------------------------------------------------------
+<llppconfig>
+<ui-font size='20'/>
+<defaults
+  width='1200'
+  height='1000'
+  ...
+  use-document-css='true'/>
+  <doc path='/some/path/file1.pdf'
+    page='1'
+    ...
+    height='1000'/>
+  <doc path='/some/path/file2.pdf'
+    page='3'
+    ...
+    height='600'/>
+  ...
+</llppconfig>
+-------------------------------------------------------------
+
+==== Some configuration tips
+- To change the user interface font add a ui-font in the followig way:
+-------------------------------------------------------------
+<llppconfig>
+  <ui-font size='16'>
+    <![CDATA[/usr/share/fonts/TTF/DejaVuSansMono.ttf]]>
+  </ui-font>
+  <defaults ... />
+</llppconfig>
+-------------------------------------------------------------
+- To change the key bindings, add keymaps to the defaults element, e.g.
+disable Escape key in the view mode:
+-------------------------------------------------------------
+<llppconfig>
+  <defaults ... >
+    <keymap mode='view'>
+      <map in='esc' out=/>
+    </keymap>
+  </defaults>
+</llppconfig>
+-------------------------------------------------------------
+The different modes are _birdseye_, _global_, _help_, _info_, _listview_, _outline_, and _view_.
+
+== TODO
+
+There is still lot of work to do. Please check our bugtracker for up-to-date
+information about tasks which are still not finished.
+
+== SEE ALSO
+
+llppac(1), llpphtml(1)
+
+== AUTHOR
+
+moosotc and contributors

--- a/man/llppac.man
+++ b/man/llppac.man
@@ -1,0 +1,41 @@
+llppac(1)
+=======
+
+== NAME
+
+llppac - a wrapper to llpp(1), which first converts documents then
+displays them with llpp
+
+== SYNOPSIS
+
+llppac [-c css] [-m type] [-t type] [-f] (path|file)
+
+== DESCRIPTION
+
+*llppac* is a wrapper to *llpp*. It converts different documents to PDF files
+which are then opened with llpp(1).
+
+== OPTIONS
+
+-c css::
+Use css as a CSS file for the html conversion using prince (http://www.princexml.com/).
+
+-f::
+Force downloading of remote documents, even though it might be cached.
+
+-m type::
+Set the mime type manually. This overwrites the automatic detection
+using file(1).
+
+-t type::
+Set the type of the the document, totally skipping the mime type check.
+The type is llppac internal, possible values include, but are not limited to _ps_, _texi_, _djvu_, _html_, ...
+
+
+== SEE ALSO
+
+llpp(1)
+
+== AUTHOR
+
+moosotc and contributors

--- a/man/llpphtml.man
+++ b/man/llpphtml.man
@@ -1,0 +1,32 @@
+llpphtml(1)
+===========
+
+== NAME
+
+llpphtml - a wrapper to llpp(1), which downloads HTML pages and
+displays them with llpp
+
+== SYNOPSIS
+
+llpphtml [-c css] [-f] url
+
+== DESCRIPTION
+
+*llppac* is a wrapper to *llpp*. It converts different documents to PDF files
+which are then opened with llpp(1).
+
+== OPTIONS
+
+-c css::
+Use css as a CSS file for the html conversion using prince (http://www.princexml.com/).
+
+-f::
+Force downloading the document, even though it might be cached.
+
+== SEE ALSO
+
+llpp(1)
+
+== AUTHOR
+
+moosotc and contributors


### PR DESCRIPTION
This adds minimal man pages for llpp, llppac, and llpphtml.
This only really makes sense, if these man pages will be kept up to date, but I think it would be quite benificial.
Please also check that the description of the options is correct. And also elaborate on some of the short option descriptions, as I was no shure what they were doing exactly.