### PR TITLE
Set LC_CTYPE to UTF-8 when launched using LaunchServices

### DIFF
--- a/misc/Info.plist.sh
+++ b/misc/Info.plist.sh
@@ -26,6 +26,11 @@ cat <<EOF
 			</array>
 		</dict>
 	</array>
+        <key>LSEnvironment</key>
+        <dict>
+                <key>LC_CTYPE</key>
+                <string>en_US.UTF-8</string>
+        </dict>
 	<key>CFBundleExecutable</key>
 	<string>llpp</string>
 	<key>CFBundleIdentifier</key>


### PR DESCRIPTION
When launching `llpp` from the terminal under macOS it inherits the locale from your terminal session, typically `UTF-8`. But when launching `llpp.app` via double-clicking or from the Finder, it is launched without a parent "terminal" and it takes the locale from the "Language" system setting (typically Latin-1 for English).

Here we fix this by setting the environment used by LaunchServices by hand in `Info.plist` to `UTF-8`.