### PR TITLE
Build fixes

### DIFF
--- a/link.c
+++ b/link.c
@@ -3437,9 +3437,9 @@ CAMLprim value ml_keysymtoutf8 (value keysym_v)
 {
     CAMLparam1 (keysym_v);
     CAMLlocal1 (str_v);
-    KeySym keysym = Int_val (keysym_v);
+    uint32_t keysym = Int_val (keysym_v);
     Rune rune;
-    extern long keysym2ucs (KeySym);
+    extern long keysym2ucs (uint32_t);
     int len;
     char buf[5];
 

--- a/wsi/x11/keysym2ucs.c
+++ b/wsi/x11/keysym2ucs.c
@@ -37,6 +37,8 @@
  * AUTOMATICALLY GENERATED FILE, DO NOT EDIT !!! (unicode/convmap.pl)
  */
 
+#include <inttypes.h>
+
 struct codepair {
   unsigned short keysym;
   unsigned short ucs;
@@ -816,7 +818,7 @@ struct codepair {
   { 0x20ac, 0x20ac }, /*                    EuroSign € EURO SIGN */
 };
 
-long keysym2ucs(KeySym keysym)
+long keysym2ucs(uint32_t keysym)
 {
     int min = 0;
     int max = sizeof(keysymtab) / sizeof(struct codepair) - 1;


### PR DESCRIPTION
Source code, e.g. #include, belongs in the source code, not the build system. Build systems are for defining include paths, not the includes themselves.

Drop the KeySym keyword since it seems to be a useless alias for uint32_t which might as well be used directly instead of indirectly using #define everywhere.

Also restore the desktop file, since desktop files do not go stale. llpp has not stopped accepting the CLI semantic `llpp /path/to/file.pdf`.