### PR TITLE
Implement missing tunables -S & -s

### DIFF
--- a/help.ml
+++ b/help.ml
@@ -100,8 +100,6 @@ S                   - slide show mode
 
 -----Tunables-----
 -i          - toggle case sensitivity of searches
--s<number>  - set scroll step (pixels)
--S<number>  - set space between pages (pixels)
 -R<number>  - rotate
 -v          - toggle verbosity
 -Z<number>  - set zoom (percent)


### PR DESCRIPTION
These were documented in help but never implemented. Note that intentry
does error checking so (int_of_string s) should always succeed.

Negative values are allowed for both parameters (as when set via info
mode), and may actually be useful for both. Negative scroll step does
inverse scrolling, and negative inter-page space makes pages overlap in
a reasonable way.