### PR TITLE
Add anki deck to documentation

### DIFF
--- a/adoc/llpp.adoc
+++ b/adoc/llpp.adoc
@@ -62,6 +62,13 @@ Set page height for reflowable documents (-1 == default, 0 == unlimited)
 -v::
 Print version and exit
 
+== KEY BINDINGS
+Open a document with llpp, then press `F1` or `h` to switch to help mode.
+
+To remember all key bindings, an Anki deck has been made available:
+
+    https://ankiweb.net/shared/info/1547122548
+
 == FILES
 
 === ~/.config/llpp.conf


### PR DESCRIPTION
This is a suggestion to help users with remembering the not often used yet useful shortcuts.
Having to search the help text everytime we need something is time consuming, and we might forget that a feature is there at all (eg `[` and `]` for brightness control. It's simpler to just learn them :)