### PR TITLE
Read paper color from config

### DIFF
--- a/config.ml
+++ b/config.ml
@@ -745,6 +745,7 @@ let config_of c attrs =
       | "slice-height" -> { c with sliceheight = maxv 2 v }
       | "thumbnail-width" -> { c with thumbw = maxv 2 v }
       | "background-color" -> { c with bgcolor = color_of_string v }
+      | "paper-color" -> { c with papercolor = rgba_of_string v }
       | "scrollbar-color" -> { c with sbarcolor = rgba_of_string v }
       | "scrollbar-handle-color" -> { c with sbarhndlcolor = rgba_of_string v }
       | "texture-color" -> { c with texturecolor = rgba_of_string v }
@@ -1237,6 +1238,7 @@ let add_attrs bb always dc c time =
   oi "slice-height" c.sliceheight dc.sliceheight;
   oi "thumbnail-width" c.thumbw dc.thumbw;
   oc "background-color" c.bgcolor dc.bgcolor;
+  oA "paper-color" c.papercolor dc.papercolor;
   oA "scrollbar-color" c.sbarcolor dc.sbarcolor;
   oA "scrollbar-handle-color" c.sbarhndlcolor dc.sbarhndlcolor;
   oA "texture-color" c.texturecolor dc.texturecolor;

--- a/ffi.ml
+++ b/ffi.ml
@@ -17,6 +17,7 @@ external postprocess :
   = "ml_postprocess";;
 external pagebbox : opaque -> bbox = "ml_getpagebox";;
 external setaalevel : int -> unit = "ml_setaalevel";;
+external setpapercolor : (float * float * float * float) -> unit = "ml_setpapercolor";;
 external realloctexts : int -> bool = "ml_realloctexts";;
 external findlink : opaque -> linkdir -> link = "ml_findlink";;
 external getlink : opaque -> int -> under = "ml_getlink";;

--- a/genconfstr.sh
+++ b/genconfstr.sh
@@ -90,6 +90,7 @@ g texcount texcount 256
 g sliceheight sliceheight 24
 g thumbw width 76
 g bgcolor rgb "(0.5, 0.5, 0.5)"
+g papercolor rgba "(1.0, 1.0, 1.0, 0.0)"
 g sbarcolor rgba "(0.64, 0.64, 0.64, 0.7)"
 g sbarhndlcolor rgba "(0.0, 0.0, 0.0, 0.7)"
 g texturecolor rgba "(0.0, 0.0, 0.0, 0.0)"

--- a/link.c
+++ b/link.c
@@ -165,6 +165,7 @@ static struct {
     GLenum texty;
 
     fz_colorspace *colorspace;
+    float papercolor[4];
 
     struct {
         int w, h;
@@ -614,7 +615,10 @@ static struct tile *rendertile (struct page *page, int x, int y, int w, int h,
 
     tile->w = w;
     tile->h = h;
-    fz_clear_pixmap_with_value (state.ctx, tile->pixmap, 0xff);
+    fz_fill_pixmap_with_color (state.ctx, tile->pixmap,
+                               fz_device_rgb(state.ctx),
+                               state.papercolor,
+                               fz_default_color_params(state.ctx));
 
     dev = fz_new_draw_device (state.ctx, fz_identity, tile->pixmap);
     ctm = pagectm (page);
@@ -3320,6 +3324,18 @@ void ml_setaalevel (value level_v)
     CAMLparam1 (level_v);
 
     state.aalevel = Int_val (level_v);
+    CAMLreturn0;
+}
+
+void ml_setpapercolor (value rgba_v);
+void ml_setpapercolor (value rgba_v)
+{
+    CAMLparam1 (rgba_v);
+
+    state.papercolor[0] = Double_val (Field (rgba_v, 0));
+    state.papercolor[1] = Double_val (Field (rgba_v, 1));
+    state.papercolor[2] = Double_val (Field (rgba_v, 2));
+    state.papercolor[3] = Double_val (Field (rgba_v, 3));
     CAMLreturn0;
 }
 

--- a/link.c
+++ b/link.c
@@ -1368,7 +1368,8 @@ static void * mainloop (void UNUSED_ATTR *unused)
             }
             fz_catch (state.ctx) {
                 utf8filename = mbtoutf8 (filename);
-                printd ("msg Could not open %s", utf8filename);
+                printd ("emsg Error loading %s: %s",
+                        utf8filename, fz_caught_message (state.ctx));
                 if (utf8filename != filename) {
                     free (utf8filename);
                 }

--- a/main.ml
+++ b/main.ml
@@ -778,6 +778,7 @@ let opendoc path password =
 
   flushpages ();
   setaalevel conf.aalevel;
+  setpapercolor conf.papercolor;
   let titlepath =
     if emptystr state.origin
     then path
@@ -2599,6 +2600,14 @@ let enterinfomode =
         colorp "   background"
           (fun () -> conf.bgcolor)
           (fun v -> conf.bgcolor <- v);
+
+        rgba "   paper color"
+          (fun () -> conf.papercolor)
+          (fun v ->
+            conf.papercolor <- v;
+            setpapercolor conf.papercolor;
+            flushtiles ();
+          );
         rgba "   scrollbar"
           (fun () -> conf.sbarcolor)
           (fun v -> conf.sbarcolor <- v);

--- a/main.ml
+++ b/main.ml
@@ -1380,9 +1380,7 @@ let act cmds =
                sub 10 2 ':';
                sub 12 2 ':';
                sub 14 2 ' ';
-               Buffer.add_char b '[';
-               Buffer.add_string b v;
-               Buffer.add_char b ']';
+               Printf.bprintf b  "[%s]" v;
                Buffer.contents b
              else args
            )

--- a/misc/llppac
+++ b/misc/llppac
@@ -111,6 +111,7 @@ kerning
     Julia          [J ulia | Jul i a]
     Singapore      [Si ng apore]
     Georgy         [Ge orgy]
+    Joe Armstrong  [J oe (rip :()]
 
 almost kerning
     hope doesn't


### PR DESCRIPTION
Make use of fz_fill_pixmap_with_color() to allow customizing background
color of pages.

Introduces new option named paper-color of type r/g/b/a.