### PR TITLE
Fixed data structure corruption in the navigation history.

### DIFF
--- a/config.ml
+++ b/config.ml
@@ -297,12 +297,16 @@ type state =
   ; mutable lnava         : (pageno * linkno) option
   ; mutable slideshow     : int
   ; mutable reload        : (x * y * float) option
+  ; mutable nav           : nav
   }
 and hists =
   { pat : string circbuf
   ; pag : string circbuf
-  ; nav : anchor circbuf
   ; sel : string circbuf
+  }
+and nav =
+  { past   : anchor list
+  ; future : anchor list
   }
 ;;
 
@@ -420,8 +424,7 @@ let state =
   ; nameddest     = E.s
   ; geomcmds      = E.s, []
   ; hists         =
-      { nav       = cbnew 10 emptyanchor
-      ; pat       = cbnew 10 E.s
+      { pat       = cbnew 10 E.s
       ; pag       = cbnew 10 E.s
       ; sel       = cbnew 10 E.s
       }
@@ -446,6 +449,10 @@ let state =
   ; lnava         = None
   ; slideshow     = 0
   ; reload        = None
+  ; nav           =
+      { past      = []
+      ; future    = []
+      }
   }
 ;;
 
@@ -1168,7 +1175,6 @@ let load openlast =
     state.x <- px;
     state.origin <- po;
     state.anchor <- pa;
-    cbput state.hists.nav pa;
     true
   in
   load1 f

--- a/main.ml
+++ b/main.ml
@@ -698,12 +698,11 @@ let getanchory (n, top, dtop) =
   else y + truncate (top*.float h -. dtop*.float conf.interpagespace)
 ;;
 
-let addnav () = getanchor () |> cbput state.hists.nav;;
-let addnavnorc () = getanchor () |> cbput_dont_update_rc state.hists.nav;;
-
-let getnav dir =
-  let anchor = cbgetc state.hists.nav dir in
-  getanchory anchor;
+let addnav () =
+  state.nav <-
+    { past = getanchor () :: state.nav.past
+    ; future = []
+    }
 ;;
 
 let gotopage n top =
@@ -3452,10 +3451,6 @@ let viewkeyboard key mask =
         end;
      end;
 
-  | Backspace ->
-     addnavnorc ();
-     gotoxy state.x (getnav ~-1)
-
   | Ascii 'o' -> enteroutlinemode ()
   | Ascii 'H' -> enterhistmode ()
 
@@ -3790,11 +3785,27 @@ let viewkeyboard key mask =
      gotoxy 0 (clamp state.maxy)
 
   | Right when Wsi.withalt mask ->
-     addnavnorc ();
-     gotoxy state.x (getnav 1)
-  | Left when Wsi.withalt mask ->
-     addnavnorc ();
-     gotoxy state.x (getnav ~-1)
+     let nav = state.nav in
+     (match nav.future with
+     | [] -> ()
+     | next :: frest ->
+        state.nav <-
+          { past = getanchor () :: nav.past
+          ; future = frest
+          };
+        gotoxy state.x (getanchory next)
+     )
+  | Backspace | Left when Wsi.withalt mask ->
+     let nav = state.nav in
+     (match nav.past with
+     | [] -> ()
+     | prev :: prest ->
+        state.nav <-
+          { past = prest
+          ; future = getanchor () :: nav.future
+          };
+        gotoxy state.x (getanchory prev)
+     )
 
   | Ascii 'r' ->
      reload ()


### PR DESCRIPTION
The way history was set up before, every time there was a history navigation with alt-left or alt-right, a new history entry would get added onto the end of the list. Maybe. It was hard to tell. Choice of a ring buffer to store history made state change semantics extremely difficult to work out. Whatever it was doing before, it was definitely broken in some way.

I fixed it by changing the navigation history state to a more suitable data structure. It now uses a cursor pattern, keeping the history in two linked lists, the past and the future.