### PR TITLE
Some fixes for macOS 10.15.5

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,25 @@
+name: main
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - macos-latest
+          - ubuntu-latest
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+    - name: download mupdf
+      run: mkdir build && sh misc/getmupdf.sh build/mupdf
+    - name: Install opengl
+      if: matrix.os == 'ubuntu-latest'
+      run: sudo apt-get install libgl1-mesa-dev
+    - name: build
+      run: bash build.bash build

--- a/build.bash
+++ b/build.bash
@@ -16,7 +16,8 @@ case "$(uname)" in
     Darwin)
         darwin=true
         wsid="wsi/cocoa"
-        mjobs=$(getconf _NPROCESSORS_ONLN || echo 1);;
+        mjobs=$(getconf _NPROCESSORS_ONLN || echo 1)
+        mbt=${mbt:-release};;
     Linux) mjobs=$(getconf _NPROCESSORS_ONLN || echo 1);;
     OpenBSD) mjobs=$(getconf NPROCESSORS_ONLN || echo 1);;
     *) die $(uname) is not supported;;
@@ -127,8 +128,8 @@ test "$overs" = "4.10.0" || {
     overs=$(ocamlc -vnum 2>/dev/null)
 }
 
-ccomp=${LLPP_CC-$(ocamlc -config | grep "^c_compiler: " | \
-                      { read _ c; echo $c; })}
+ccomp=${LLPP_CC-`ocamlc -config | grep "^c_compiler: " | \
+                      { read _ c; echo $c; }`}
 cvers="$($ccomp --version | { read a; echo $a; } )"
 
 bocaml1() {


### PR DESCRIPTION
First commit: two fixes:

- compile `mupdf` in `release` mode instead of `native` mode. Indeed, compiling in `native` mode passes `-march=native` to `clang`, which enables a bunch of optimizations, and crashes with:
```
fatal error: error in backend: Cannot emit physreg copy instruction
clang: error: clang frontend command failed with exit code 70 (use -v to see invocation)
Apple clang version 11.0.3 (clang-1103.0.32.62)
Target: x86_64-apple-darwin19.5.0
Thread model: posix
InstalledDir: /Library/Developer/CommandLineTools/usr/bin
clang: note: diagnostic msg: PLEASE submit a bug report to http://developer.apple.com/bugreporter/ and include the crash backtrace, preprocessed source, and associated run script.
clang: note: diagnostic msg: 
********************

PLEASE ATTACH THE FOLLOWING FILES TO THE BUG REPORT:
Preprocessed source(s) and associated run script(s) are located at:
clang: note: diagnostic msg: /var/folders/wk/tmnd6vvn0sg6lmfgg9mvckcr0000gn/T/cmstypes-a89bf6.c
clang: note: diagnostic msg: /var/folders/wk/tmnd6vvn0sg6lmfgg9mvckcr0000gn/T/cmstypes-a89bf6.sh
clang: note: diagnostic msg: Crash backtrace is located in
clang: note: diagnostic msg: /Users/nojb/Library/Logs/DiagnosticReports/clang_<YYYY-MM-DD-HHMMSS>_<hostname>.crash
clang: note: diagnostic msg: (choose the .crash file that corresponds to your crash)
clang: note: diagnostic msg: 

********************
```
(see log at https://github.com/nojb/llpp/runs/951325249?check_suite_focus=true#step:5:332)

(problem identified and solved by @diremy)

- work around a problem with the `bash` of `macOS` in the `build.bash` script: an expression of the form
```
${XXX-$(echo a | { read c; echo $c; })}
```
fails with
```
-bash: syntax error near unexpected token `)'
```
A "solution" is to replace `$(...)` by backquotes.

---

The second commit sets up some CI thingy so that every push or PR in github triggers an automatic build of llpp under both Ubuntu and macOS, in case you feel like trying it out. (see sample log at https://github.com/nojb/llpp/runs/951298331?check_suite_focus=true#step:5:2780).